### PR TITLE
add desync mode and stall prevention

### DIFF
--- a/NewConnectors/RenderQueueProcessor.cs
+++ b/NewConnectors/RenderQueueProcessor.cs
@@ -46,9 +46,7 @@ public class RenderQueueProcessor : MonoBehaviour
     {
         bool useBatchProcessing = Thundagun.CurrentSyncMode == Thundagun.SyncMode.Async;
         bool departEarly = Thundagun.CurrentSyncMode == Thundagun.SyncMode.Desync;
-        TimeSpan timeOffset = (DateTime.Now - Thundagun.unityStartTime) - TimeSpan.FromMilliseconds(Thundagun.timeBudget);
-        Thundagun.timeBudget =  Thundagun.timeBudget - timeOffset.TotalMilliseconds;
-        DateTime departureTime = DateTime.Now + TimeSpan.FromMilliseconds(Thundagun.timeBudget);
+        DateTime departureTime = DateTime.Now + TimeSpan.FromMilliseconds(Thundagun.resoniteEMA);
         lock (batchQueue)
         {
             if (batchQueue.Count == 0)
@@ -84,10 +82,6 @@ public class RenderQueueProcessor : MonoBehaviour
                     var batch = batchQueue.Peek();
                     while (batch.Tasks.Count > 0)
                     {
-                        if (departEarly && (DateTime.Now > departureTime))
-                        {
-                            break;
-                        }
                         var renderTask = batch.Tasks.Dequeue();
                         try
                         {
@@ -97,16 +91,18 @@ public class RenderQueueProcessor : MonoBehaviour
                         {
                             renderTask.task.SetException(ex);
                         }
+                        if (departEarly && (DateTime.Now > departureTime))
+                        {
+                            break;
+                        }
                     }
-                    // This is added to avoid accidentally dequeuing the batch if we are departing early and left tasks behind
-                    // In the rare chance that the batch was actually fully processed, it'll be dequeued the next frame
+                    if (batch.IsComplete && batch.Tasks.Count == 0)
+                    {
+                        batchQueue.Dequeue(); 
+                    }
                     if (departEarly && (DateTime.Now > departureTime))
                     {
                         break;
-                    }
-                    if (batch.IsComplete)
-                    {
-                        batchQueue.Dequeue(); 
                     }
                 }
             }

--- a/NewConnectors/RenderQueueProcessor.cs
+++ b/NewConnectors/RenderQueueProcessor.cs
@@ -52,12 +52,12 @@ public class RenderQueueProcessor : MonoBehaviour // compare
 
         // current timestamp
         DateTime now = DateTime.Now;
-        // checks if we're in a batch/sync holding pattern
+        // checks if we're in a batch holding pattern
         double timeSinceLastStateUpdate = (now - Thundagun.lastStateUpdate).TotalMilliseconds;
         // we can only know the batch flag from the ema
         bool useBatchProcessing = Thundagun.CurrentSyncMode == Thundagun.SyncMode.Async;
 
-        // if we've been skipping/waiting for too long
+        // if we've been skipping for too long
         if (timeSinceLastStateUpdate > timeoutThreshold)
         {
             // enter a timeout
@@ -66,7 +66,7 @@ public class RenderQueueProcessor : MonoBehaviour // compare
             useBatchProcessing = false;
         }
 
-        double timeElapsed = 0;
+        double timeElapsed;
 
         lock (batchQueue)
         {

--- a/NewConnectors/RenderQueueProcessor.cs
+++ b/NewConnectors/RenderQueueProcessor.cs
@@ -44,24 +44,17 @@ public class RenderQueueProcessor : MonoBehaviour
 
     private void LateUpdate()
     {
-        // reused config values
         double timeoutThreshold = Thundagun.Config.GetValue(Thundagun.TimeoutThreshold);
         double timeoutCooldown = Thundagun.Config.GetValue(Thundagun.TimeoutCooldown);
         double timeoutWorkInterval = Thundagun.Config.GetValue(Thundagun.TimeoutWorkInterval);
 
-        // current timestamp
         DateTime now = DateTime.Now;
-        // checks if we're in a batch holding pattern
         double timeSinceLastStateUpdate = (now - Thundagun.lastStateUpdate).TotalMilliseconds;
-        // we can only know the batch flag from the ema
         bool useBatchProcessing = Thundagun.CurrentSyncMode == Thundagun.SyncMode.Async;
 
-        // if we've been skipping for too long
         if (timeSinceLastStateUpdate > timeoutThreshold)
         {
-            // enter a timeout
             Thundagun.lastTimeout = now;
-            // ensure we stop batching this iteration to escape the holding pattern early
             useBatchProcessing = false;
         }
 
@@ -79,17 +72,14 @@ public class RenderQueueProcessor : MonoBehaviour
 
             while (batchQueue.Count > 0)
             {
-                // gets the oldest batch?
                 var batch = batchQueue.Peek();
 
-                // fine for normal batching or holding pattern
                 if (!batch.IsComplete && useBatchProcessing)
                 {
                     return;
                 }
 
 
-                // start tracking time now that there is work to do
                 Thundagun.lastStateUpdate = now;
 
                 while (batch.Tasks.Count > 0)
@@ -103,34 +93,25 @@ public class RenderQueueProcessor : MonoBehaviour
                     {
                         renderTask.task.SetException(ex);
                     }
-                    // update the current time
                     now = DateTime.Now;
-                    // figure out how long we've been working for
                     timeElapsed = (now - Thundagun.lastStateUpdate).TotalMilliseconds;
-                    // if we're in a timeout currently
                     if (now - Thundagun.lastTimeout < TimeSpan.FromSeconds(timeoutCooldown))
                     {
-                        // if we've been working for too long
                         if (timeElapsed > timeoutWorkInterval)
                         {
                             break;
                         }
                     }
                 }
-                // update the current time
                 now = DateTime.Now;
-                // figure out how long we've been working for
                 timeElapsed = (now - Thundagun.lastStateUpdate).TotalMilliseconds;
-                // if we're in a timeout currently
                 if (now - Thundagun.lastTimeout < TimeSpan.FromSeconds(timeoutCooldown))
                 {
-                    // if we've been working for too long
                     if (timeElapsed > timeoutWorkInterval)
                     {
                         break;
                     }
                 }
-                // remove the batch if it's empty and completed
                 if (batch.IsComplete && batch.Tasks.Count == 0)
                 {
                     batchQueue.Dequeue();

--- a/NewConnectors/RenderQueueProcessor.cs
+++ b/NewConnectors/RenderQueueProcessor.cs
@@ -2,13 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using FrooxEngine;
-using Leap;
 using UnityEngine;
 using UnityFrooxEngineRunner;
 
 namespace Thundagun.NewConnectors;
 
-public class RenderQueueProcessor : MonoBehaviour // compare
+public class RenderQueueProcessor : MonoBehaviour
 {
     public RenderConnector Connector;
 
@@ -25,7 +24,7 @@ public class RenderQueueProcessor : MonoBehaviour // compare
         }
     }
 
-    public Task<byte[]> Enqueue(FrooxEngine.RenderSettings settings) // compare
+    public Task<byte[]> Enqueue(FrooxEngine.RenderSettings settings)
     {
         var task = new TaskCompletionSource<byte[]>();
         var renderTask = new RenderTask(settings, task);

--- a/NewConnectors/RenderQueueProcessor.cs
+++ b/NewConnectors/RenderQueueProcessor.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using FrooxEngine;
 using Leap;
@@ -10,7 +8,7 @@ using UnityFrooxEngineRunner;
 
 namespace Thundagun.NewConnectors;
 
-public class RenderQueueProcessor : MonoBehaviour
+public class RenderQueueProcessor : MonoBehaviour // compare
 {
     public RenderConnector Connector;
 
@@ -27,7 +25,7 @@ public class RenderQueueProcessor : MonoBehaviour
         }
     }
 
-    public Task<byte[]> Enqueue(FrooxEngine.RenderSettings settings)
+    public Task<byte[]> Enqueue(FrooxEngine.RenderSettings settings) // compare
     {
         var task = new TaskCompletionSource<byte[]>();
         var renderTask = new RenderTask(settings, task);
@@ -47,58 +45,57 @@ public class RenderQueueProcessor : MonoBehaviour
 
     private void LateUpdate()
     {
-        // cache config values
-        //bool useBatchProcessing = Thundagun.CurrentSyncMode == Thundagun.SyncMode.Async; // fix batch processing later
+        // reused config values
         double timeoutThreshold = Thundagun.Config.GetValue(Thundagun.TimeoutThreshold);
         double timeoutCooldown = Thundagun.Config.GetValue(Thundagun.TimeoutCooldown);
         double timeoutWorkInterval = Thundagun.Config.GetValue(Thundagun.TimeoutWorkInterval);
 
-        // set arrival time
-        DateTime arrivalTime = DateTime.Now;
+        // current timestamp
+        DateTime now = DateTime.Now;
+        // checks if we're in a batch/sync holding pattern
+        double timeSinceLastStateUpdate = (now - Thundagun.lastStateUpdate).TotalMilliseconds;
+        // we can only know the batch flag from the ema
+        bool useBatchProcessing = Thundagun.CurrentSyncMode == Thundagun.SyncMode.Async;
 
-        // define shared variables
-        DateTime now;
-        double timeElapsed;
+        // if we've been skipping/waiting for too long
+        if (timeSinceLastStateUpdate > timeoutThreshold)
+        {
+            // enter a timeout
+            Thundagun.lastTimeout = now;
+            // ensure we stop batching this iteration to escape the holding pattern early
+            useBatchProcessing = false;
+        }
 
-        // begin processing
+        double timeElapsed = 0;
+
         lock (batchQueue)
         {
-            // if no tasks, return
             if (batchQueue.Count == 0)
             {
                 return;
             }
-            // if only one task, check if it is complete
-            //else if (batchQueue.Count == 1)
-            //{
-            //    if (useBatchProcessing && !batchQueue.Peek().IsComplete)
-            //    {
-            //        return;
-            //    }
-            //}
 
             var renderingContext = RenderHelper.CurrentRenderingContext;
             RenderHelper.BeginRenderContext(RenderingContext.RenderToAsset);
 
-            // while we still have batches left
             while (batchQueue.Count > 0)
             {
-                // get the oldest batch?
+                // gets the oldest batch?
                 var batch = batchQueue.Peek();
 
-                // if the last batch isn't done yet and we're batching
-                //if (!batch.IsComplete && useBatchProcessing)
-                //{
-                //    // don't process the unfinished batch
-                //    return;
-                //}
+                // fine for normal batching or holding pattern
+                if (!batch.IsComplete && useBatchProcessing)
+                {
+                    return;
+                }
 
-                // while we still have tasks left
+
+                // start tracking time now that there is work to do
+                Thundagun.lastStateUpdate = now;
+
                 while (batch.Tasks.Count > 0)
                 {
-                    // pop off a render task
                     var renderTask = batch.Tasks.Dequeue();
-                    // try to apply it
                     try
                     {
                         renderTask.task.SetResult(Connector.RenderImmediate(renderTask.settings));
@@ -107,58 +104,40 @@ public class RenderQueueProcessor : MonoBehaviour
                     {
                         renderTask.task.SetException(ex);
                     }
-                    // update now
+                    // update the current time
                     now = DateTime.Now;
-                    // update time elapsed
-                    timeElapsed = (now - arrivalTime).TotalMilliseconds;
-                    // see if we're in an active timeout
+                    // figure out how long we've been working for
+                    timeElapsed = (now - Thundagun.lastStateUpdate).TotalMilliseconds;
+                    // if we're in a timeout currently
                     if (now - Thundagun.lastTimeout < TimeSpan.FromSeconds(timeoutCooldown))
                     {
-                        // help the ema catch up
-                        Thundagun.unityEMA = timeoutThreshold;
-                        // we might still be in async, ensure we stop doing the whole batch
-                        //useBatchProcessing = false;
-                        // if so, see if we're running over schedule
+                        // if we've been working for too long
                         if (timeElapsed > timeoutWorkInterval)
                         {
-                            // if so, break out
                             break;
                         }
                     }
-                    else // not in an active timeout, should check if we might be in one
-                    {
-                        if (timeElapsed > timeoutThreshold)
-                        {
-                            // update the last timeout to enter a timeout state again
-                            Thundagun.lastTimeout = now;
-                        }
-
-                    }
                 }
+                // update the current time
                 now = DateTime.Now;
-                timeElapsed = (now - arrivalTime).TotalMilliseconds;
-                // see if we're in an active timeout
+                // figure out how long we've been working for
+                timeElapsed = (now - Thundagun.lastStateUpdate).TotalMilliseconds;
+                // if we're in a timeout currently
                 if (now - Thundagun.lastTimeout < TimeSpan.FromSeconds(timeoutCooldown))
                 {
-                    // help the ema catch up
-                    Thundagun.unityEMA = timeoutThreshold;
-                    // we might still be in async, ensure we stop doing the whole batch
-                    //useBatchProcessing = false;
-                    // if so, see if we're running over schedule
+                    // if we've been working for too long
                     if (timeElapsed > timeoutWorkInterval)
                     {
-                        // if so, break out
                         break;
                     }
                 }
-                // if a finished batch has been emptied
+                // remove the batch if it's empty and completed
                 if (batch.IsComplete && batch.Tasks.Count == 0)
                 {
-                    // remove finished empty batch
                     batchQueue.Dequeue();
                 }
             }
-         
+
 
             if (renderingContext.HasValue)
             {

--- a/NewConnectors/RenderQueueProcessor.cs
+++ b/NewConnectors/RenderQueueProcessor.cs
@@ -44,22 +44,6 @@ public class RenderQueueProcessor : MonoBehaviour
 
     private void LateUpdate()
     {
-        /*
-        double timeoutThreshold = Thundagun.Config.GetValue(Thundagun.TimeoutThreshold);
-        double timeoutCooldown = Thundagun.Config.GetValue(Thundagun.TimeoutCooldown);
-        double timeoutWorkInterval = Thundagun.Config.GetValue(Thundagun.TimeoutWorkInterval);
-
-        DateTime now = DateTime.Now;
-        double timeSinceLastStateUpdate = (now - Thundagun.lastStateUpdate).TotalMilliseconds;
-        bool useBatchProcessing = Thundagun.CurrentSyncMode == Thundagun.SyncMode.Async;
-
-        if (timeSinceLastStateUpdate > timeoutThreshold)
-        {
-            Thundagun.lastTimeout = now;
-            useBatchProcessing = false;
-        }
-        */
-
         lock (batchQueue)
         {
             if (batchQueue.Count == 0)

--- a/README.md
+++ b/README.md
@@ -8,36 +8,10 @@ Thundagun is a Resonite mod that decouples the game logic and rendering loops by
 
 - **Parallel Execution**: Maximizes CPU and GPU utilization by running Resonite and Unity on separate threads.
 - **Sync Mode**: Ensures a consistent 1:1 ratio between game updates and frames for stable visuals.
-- **Async Mode**: Allows Unity to render frames independently, improving responsiveness by potentially skipping over multiple states to use the latest or by rendering older states when new ones aren't available.
-- **Auto Mode**: Automatically switches between Sync and Async modes based on the game's performance.
-- **Decoupled Input Handling**: Moves input processing to Unity, enabling continuous player movement and camera control even if Resonite stalls.
-- **Batch Processing**: Uses a batch queue system for managing updates, ensuring safe and efficient change processing.
-- **Thread-Safe Locking**: Ensures thread locking/unlocking behavior is thread-safe and protected against deadlocks.
-
-## Modes of Operation
-
-### Sync Mode
-
-The recommended mode for new users. Ensures each frame corresponds to one game update. Ideal for users prioritizing consistent frame timing and visual stability:
-
-- **Synchronized Execution**: Resonite and Unity run in parallel but can briefly wait on each other if needed.
-- **Immediate Processing**: Changes are processed as soon as they become available.
-- **Stable Visuals**: Minimizes discrepancies between game updates and frame rendering.
-
-### Async Mode
-
-A more experimental mode for more experienced users. Allows stale states to be redrawn from a different perspective, and uses the most recent state if the queue has accumulated two or more batches. Offers increased flexibility and responsiveness, especially beneficial for VR applications:
-
-- **Independent Rendering**: Unity renders frames based on the latest completed state without waiting for Resonite.
-- **Batch Processing**: Updates are processed in batches, allowing Unity to safely redraw previous states.
-- **Enhanced Responsiveness**: Input handling, movement, and IK calculations are performed on Unity's side.
-
-### Auto Mode
-
-An even more experimental mode for technical users. Dynamically switches between sync and async modes depending on the frame times between Resonite and Unity. This is useful for defining stalling behavior by tweaking thresholds, giving the consistency benefits of sync mode and the stalling protection offered by async mode:
-
-- **EMA Weighting**: Uses exponential moving averages to accurately approximate the current frame rate.
-- **Ratio Thresholds**: Defines the frame ratio threshold for switching between sync and async modes; bidirectional and between 1 and 1000.
+- **Async Mode**: Allows Unity to render frames independently, improving responsiveness by potentially skipping over multiple finished states to use the latest or by rendering older finished states when new ones aren't available.
+- **Desync Mode**: Allows Resonite to send incremental changes to Unity during long engine stalls, and enables Unity to keep rendering even if it has a lot of changes queued.
+- **Auto Switching**: Enables thresholds to be defined for switching dynamically between sync, async, and desync modes based on game performance.
+- **Decoupled Input Handling**: Moves input, IK, and locomotion processing to Unity, enabling continuous player movement and camera control during stalls.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Thundagun is a Resonite mod that decouples the game logic and rendering loops by
 - **Parallel Execution**: Maximizes CPU and GPU utilization by running Resonite and Unity on separate threads.
 - **Sync Mode**: Ensures a consistent 1:1 ratio between game updates and frames for stable visuals.
 - **Async Mode**: Allows Unity to render frames independently, improving responsiveness by potentially skipping over multiple finished states to use the latest or by rendering older finished states when new ones aren't available.
-- **Desync Mode**: Allows Resonite to send incremental changes to Unity during long engine stalls, and enables Unity to keep rendering even if it has a lot of changes queued.
+- **Desync Mode**: Allows Resonite to send incremental changes to Unity during long engine stalls.
+- **Stall Prevention**: Uses a configurable timeout to ensure frames continue to be rendered even during massive change queuing, like world loading.
 - **Auto Switching**: Enables thresholds to be defined for switching dynamically between sync, async, and desync modes based on game performance.
 - **Decoupled Input Handling**: Moves input, IK, and locomotion processing to Unity, enabling continuous player movement and camera control during stalls.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Thundagun
 
-Thundagun is a Resonite mod that decouples the game logic and rendering loops by running Resonite and Unity on separate threads.
+Thundagun is a Resonite mod that decouples the FrooxEngine and Unity loops by running FrooxEngine and Unity on separate threads.
 
 **Warning: This mod is a prerelease. It may contain bugs and other issues. Crashes and missing/buggy visuals are possible but are generally uncommon. Use at your own risk.**
 
@@ -8,7 +8,7 @@ Thundagun is a Resonite mod that decouples the game logic and rendering loops by
 
 - **Parallel Execution**: Maximizes CPU and GPU utilization by running Resonite and Unity on separate threads.
 - **Sync Mode**: Ensures a consistent 1:1 ratio between game updates and frames for stable visuals.
-- **Async Mode**: Allows Unity to render frames independently, improving responsiveness by potentially skipping over multiple finished states to use the latest or by rendering older finished states when new ones aren't available.
+- **Async Mode**: Allows Unity to render frames independently, improving responsiveness by potentially processing multiple finished states to use the latest or by rendering older finished states when new ones aren't available.
 - **Desync Mode**: Allows Resonite to send incremental changes to Unity during long engine stalls.
 - **Stall Prevention**: Uses a configurable timeout to ensure frames continue to be rendered even during massive change queuing, like world loading.
 - **Auto Switching**: Enables thresholds to be defined for switching dynamically between sync, async, and desync modes based on game performance.

--- a/Thundagun.cs
+++ b/Thundagun.cs
@@ -26,6 +26,9 @@ public class Thundagun : ResoniteMod
     public override string Version => "1.0.0";
 
     public static double Performance;
+    // all of this is not thread safe. The synchronization logic needs to be moved into a dedicated class
+    // this class would define a single shared sync mode state
+    // It should be simple for the queueProcessor and locks to check the sync mode and act accordingly
     public static DateTime unityStartTime = DateTime.Now; // do we get start time elsewhere already?
     public static DateTime resoniteStartTime = DateTime.Now; // do we get start time elsewhere already?
     public static DateTime lastTimeout = DateTime.Now - TimeSpan.FromHours(1);
@@ -78,6 +81,7 @@ public class Thundagun : ResoniteMod
 
     internal static ModConfiguration Config;
 
+    // Implement getters for all these keys to ensure they're within proper bounds
     [AutoRegisterConfigKey]
     internal readonly static ModConfigurationKey<bool> DebugLogging =
         new("DebugLogging", "Debug Logging: Whether to enable debug logging.", () => false); // might want separate logging for Unity and Resonite sides?

--- a/Thundagun.cs
+++ b/Thundagun.cs
@@ -81,7 +81,7 @@ public class Thundagun : ResoniteMod
         new("DebugLogging", "Debug Logging: Whether to enable debug logging.", () => false);
     [AutoRegisterConfigKey]
     internal readonly static ModConfigurationKey<float> EngineTickRate =
-        new("EngineTickRate", "Engine Tick Rate: The max rate at which FrooxEngine can update.", () => 30);
+        new("EngineTickRate", "Engine Tick Rate: The max rate at which FrooxEngine can update.", () => 1000);
     [AutoRegisterConfigKey]
     internal readonly static ModConfigurationKey<double> SyncToAsyncRatioThreshold =
         new("SyncToAsyncRatioThreshold", "Sync To Async Ratio Threshold: The ratio threshold to switch from sync to async.", () => 4.0);

--- a/Thundagun.cs
+++ b/Thundagun.cs
@@ -67,7 +67,7 @@ public class Thundagun : ResoniteMod
 
     public static readonly object lockObject = new();
 
-    public static void QueuePacket(IUpdatePacket packet) 
+    public static void QueuePacket(IUpdatePacket packet)
     {
         lock (CurrentPackets)
         {
@@ -115,7 +115,7 @@ public class Thundagun : ResoniteMod
         Async,
         Desync,
     }
-    public override void OnEngineInit() 
+    public override void OnEngineInit()
     {
         var harmony = new Harmony("Thundagun");
         Config = GetConfiguration();
@@ -135,7 +135,7 @@ public class Thundagun : ResoniteMod
         harmony.PatchAll();
     }
 
-    public static void PatchEngineTypes() 
+    public static void PatchEngineTypes()
     {
         var engineTypes = typeof(Slot).Assembly.GetTypes()
             .Where(i => i.GetCustomAttribute<ImplementableClassAttribute>() is not null).ToList();
@@ -172,7 +172,7 @@ public class Thundagun : ResoniteMod
         }
     }
 
-    public static void PatchComponentConnectors(Harmony harmony) 
+    public static void PatchComponentConnectors(Harmony harmony)
     {
         var types = typeof(Thundagun).Assembly.GetTypes()
             .Where(i => i.IsClass && i.GetInterfaces().Contains(typeof(IConnector))).ToList();
@@ -547,7 +547,6 @@ public static class AssetInitializerPatch
         return false;
     }
 }
-
 
 public static class WorkerInitializerPatch
 {

--- a/Thundagun.cs
+++ b/Thundagun.cs
@@ -59,7 +59,7 @@ public class Thundagun : ResoniteMod
         }
     }
     
-    public static readonly Queue<IUpdatePacket> CurrentPackets = new(); // needed?
+    public static readonly Queue<IUpdatePacket> CurrentPackets = new(); 
 
     public static Task CurrentTask;
 
@@ -67,7 +67,7 @@ public class Thundagun : ResoniteMod
 
     public static readonly object lockObject = new();
 
-    public static void QueuePacket(IUpdatePacket packet) // check
+    public static void QueuePacket(IUpdatePacket packet) 
     {
         lock (CurrentPackets)
         {
@@ -115,7 +115,7 @@ public class Thundagun : ResoniteMod
         Async,
         Desync,
     }
-    public override void OnEngineInit() // check
+    public override void OnEngineInit() 
     {
         var harmony = new Harmony("Thundagun");
         Config = GetConfiguration();
@@ -135,7 +135,7 @@ public class Thundagun : ResoniteMod
         harmony.PatchAll();
     }
 
-    public static void PatchEngineTypes() // check
+    public static void PatchEngineTypes() 
     {
         var engineTypes = typeof(Slot).Assembly.GetTypes()
             .Where(i => i.GetCustomAttribute<ImplementableClassAttribute>() is not null).ToList();
@@ -172,7 +172,7 @@ public class Thundagun : ResoniteMod
         }
     }
 
-    public static void PatchComponentConnectors(Harmony harmony) // check
+    public static void PatchComponentConnectors(Harmony harmony) 
     {
         var types = typeof(Thundagun).Assembly.GetTypes()
             .Where(i => i.IsClass && i.GetInterfaces().Contains(typeof(IConnector))).ToList();
@@ -197,7 +197,7 @@ public class Thundagun : ResoniteMod
 }
 
 [HarmonyPatch(typeof(FrooxEngineRunner))]
-public static class FrooxEngineRunnerPatch // check
+public static class FrooxEngineRunnerPatch
 {
 
     public static Queue<int> assets_processed = new();
@@ -442,9 +442,8 @@ public static class FrooxEngineRunnerPatch // check
 
     [HarmonyReversePatch]
     [HarmonyPatch("UpdateFrameRate")]
-    public static void UpdateFrameRate(object instance) => throw new NotImplementedException("stub"); // ???
+    public static void UpdateFrameRate(object instance) => throw new NotImplementedException("stub");
 
-    // check
     private static void UpdateHeadOutput(World focusedWorld, Engine engine, HeadOutput VR, HeadOutput screen, AudioListener listener, ref List<World> worlds)
     {
         if (focusedWorld == null) return;
@@ -486,11 +485,9 @@ public static class FrooxEngineRunnerPatch // check
         worlds.Clear();
     }
 
-    // reverse patch? check
     [HarmonyReversePatch]
     [HarmonyPatch("UpdateQualitySettings")]
     public static void UpdateQualitySettings(object instance) => throw new NotImplementedException("stub");
-    // check
     private static void Shutdown(this FrooxEngineRunner runner, ref Engine engine)
     {
         UniLog.Log("Shutting down");
@@ -515,7 +512,6 @@ public static class FrooxEngineRunnerPatch // check
     }
 }
 
-// check; why are these things in root? Is this the only place for patches?
 [HarmonyPatch(typeof(AssetInitializer))]
 public static class AssetInitializerPatch
 {
@@ -553,7 +549,6 @@ public static class AssetInitializerPatch
 }
 
 
-// check
 public static class WorkerInitializerPatch
 {
     public static void Initialize(Type workerType, WorkerInitInfo __result)
@@ -580,7 +575,6 @@ public static class WorkerInitializerPatch
     }
 }
 
-// check
 public abstract class UpdatePacket<T> : IUpdatePacket
 {
     public T Owner;
@@ -592,13 +586,10 @@ public abstract class UpdatePacket<T> : IUpdatePacket
     }
 }
 
-// check
 public interface IUpdatePacket
 {
     public void Update();
 }
-
-// check
 public class PerformanceTimer
 {
     private string Name;

--- a/Thundagun.cs
+++ b/Thundagun.cs
@@ -80,8 +80,8 @@ public class Thundagun : ResoniteMod
     internal readonly static ModConfigurationKey<bool> DebugLogging =
         new("DebugLogging", "Debug Logging: Whether to enable debug logging.", () => false);
     [AutoRegisterConfigKey]
-    internal readonly static ModConfigurationKey<float> DebugLoggingTickRate =
-        new("DebugLoggingTickRate", "Debug Logging Tick Rate: The rate at which debug logs are written.", () => 30);
+    internal readonly static ModConfigurationKey<float> EngineTickRate =
+        new("EngineTickRate", "Engine Tick Rate: The max rate at which FrooxEngine can update.", () => 30);
     [AutoRegisterConfigKey]
     internal readonly static ModConfigurationKey<double> SyncToAsyncRatioThreshold =
         new("SyncToAsyncRatioThreshold", "Sync To Async Ratio Threshold: The ratio threshold to switch from sync to async.", () => 4.0);
@@ -239,7 +239,7 @@ public static class FrooxEngineRunnerPatch
                             engine.AssetsUpdated(total); 
                             engine.RunUpdateLoop(); 
                             TimeSpan engine_time = (DateTime.Now - beforeEngine);
-                            TimeSpan ticktime = TimeSpan.FromSeconds((1 / Math.Abs(Thundagun.Config.GetValue(Thundagun.DebugLoggingTickRate)) + 1));
+                            TimeSpan ticktime = TimeSpan.FromSeconds((1 / Math.Abs(Thundagun.Config.GetValue(Thundagun.EngineTickRate)) + 1));
                             if (engine_time < ticktime)
                             {
                                 Task.Delay(ticktime - engine_time);

--- a/Thundagun.cs
+++ b/Thundagun.cs
@@ -364,7 +364,7 @@ public static class FrooxEngineRunnerPatch
                 if (Thundagun.Config.GetValue(Thundagun.DebugLogging))
                 {
                     Thundagun.Msg($"LastRender vs now: {(lastrender - starttime).TotalSeconds}");
-                    Thundagun.Msg($"Boilerplate: {(boilerplateTime - starttime).TotalSeconds} Asset Integration time: {(assetTime - boilerplateTime).TotalSeconds} Loop time: {(loopTime - assetTime).TotalSeconds} Update time: {(updateTime - loopTime).TotalSeconds} Finished: {(finishTime - updateTime).TotalSeconds} total time: {(finishTime - starttime).TotalSeconds} Current mode: {Thundagun.CurrentSyncMode} ");
+                    Thundagun.Msg($"Boilerplate: {(boilerplateTime - starttime).TotalSeconds} Asset Integration time: {(assetTime - boilerplateTime).TotalSeconds} Loop time: {(loopTime - assetTime).TotalSeconds} Update time: {(updateTime - loopTime).TotalSeconds} Finished: {(finishTime - updateTime).TotalSeconds} total time: {(finishTime - starttime).TotalSeconds} Current mode: {Thundagun.CurrentSyncMode} Unity update time: {Thundagun.unityEMA} FrooxEngine update time: {Thundagun.resoniteEMA}");
                 }
                 lastrender = DateTime.Now;
             }

--- a/Thundagun.cs
+++ b/Thundagun.cs
@@ -35,12 +35,12 @@ public class Thundagun : ResoniteMod
     public static double resoniteEMA = 16.67;
     public static void UpdateUnityEMA(double frameTime)
     {
-        double alpha = Mathf.Clamp01(Config.GetValue(EMAExponent));
+        double alpha = Mathf.Clamp(Config.GetValue(EMAExponent), 0.001f, 0.999f);
         unityEMA = alpha * frameTime + (1 - alpha) * unityEMA;
     }
     public static void UpdateResoniteEMA(double frameTime)
     {
-        double alpha = Mathf.Clamp01(Config.GetValue(EMAExponent));
+        double alpha = Mathf.Clamp(Config.GetValue(EMAExponent), 0.001f, 0.999f);
         resoniteEMA = alpha * frameTime + (1 - alpha) * resoniteEMA;
     }
     public static SyncMode CurrentSyncMode
@@ -364,7 +364,7 @@ public static class FrooxEngineRunnerPatch
                 if (Thundagun.Config.GetValue(Thundagun.DebugLogging))
                 {
                     Thundagun.Msg($"LastRender vs now: {(lastrender - starttime).TotalSeconds}");
-                    Thundagun.Msg($"Boilerplate: {(boilerplateTime - starttime).TotalSeconds} Asset Integration time: {(assetTime - boilerplateTime).TotalSeconds} Loop time: {(loopTime - assetTime).TotalSeconds} Update time: {(updateTime - loopTime).TotalSeconds} Finished: {(finishTime - updateTime).TotalSeconds} total time: {(finishTime - starttime).TotalSeconds}");
+                    Thundagun.Msg($"Boilerplate: {(boilerplateTime - starttime).TotalSeconds} Asset Integration time: {(assetTime - boilerplateTime).TotalSeconds} Loop time: {(loopTime - assetTime).TotalSeconds} Update time: {(updateTime - loopTime).TotalSeconds} Finished: {(finishTime - updateTime).TotalSeconds} total time: {(finishTime - starttime).TotalSeconds} Current mode: {Thundagun.CurrentSyncMode} ");
                 }
                 lastrender = DateTime.Now;
             }

--- a/Thundagun.cs
+++ b/Thundagun.cs
@@ -33,7 +33,6 @@ public class Thundagun : ResoniteMod
     public static DateTime resoniteStartTime = DateTime.Now;
     public static double unityEMA = 16.67;
     public static double resoniteEMA = 16.67;
-    public static double timeBudget = 16.67;
     public static void UpdateUnityEMA(double frameTime)
     {
         double alpha = Mathf.Clamp01(Config.GetValue(EMAExponent));
@@ -88,7 +87,7 @@ public class Thundagun : ResoniteMod
         new("SyncToAsyncRatioThreshold", "Sync To Async Ratio Threshold: The ratio threshold to switch from sync to async.", () => 4.0);
     [AutoRegisterConfigKey]
     internal readonly static ModConfigurationKey<double> AsyncToDesyncRatioThreshold =
-    new("AsyncToDesyncRatioThreshold", "Async To Desync Ratio Threshold: The ratio threshold to switch from async to desync.", () => 99999999.0);
+    new("AsyncToDesyncRatioThreshold", "Async To Desync Ratio Threshold: The ratio threshold to switch from async to desync.", () => 64.0);
     [AutoRegisterConfigKey]
     internal readonly static ModConfigurationKey<float> EMAExponent =
         new("EMAExponent", "EMA Exponent: The exponent used for the exponential moving average for calculating framerate.", () => 0.1f);


### PR DESCRIPTION
Pretty much redoes the whole sync/async/desync system with the added benefit of a timeout.

Sync: used when either ratio is close to 1. Only renders when a new completed state is ready.
Async: used when either ratio is between 2 and 4 generally. Only renders completed states, either processing more than one completed state or reusing the existing completed state.
Desync: used when either ratio is greater than 4. Renders any state changes, even incomplete ones.
Timeout: used when the framerate drops below the playable minimum, usually due to massive FrooxEngine change dumps. Caps the amount of time Unity spends processing updates to avoid freezing up completely.

Exposes mod configs for sync-async ratio threshold, async-desync ratio threshold, timeout threshold, timeout cooldown, and timeout work interval.