### PR TITLE
Parallelization

### DIFF
--- a/NewConnectors/RenderQueueProcessor.cs
+++ b/NewConnectors/RenderQueueProcessor.cs
@@ -71,12 +71,12 @@ public class RenderQueueProcessor : MonoBehaviour
                 while (batch.Tasks.Count > 0)
                 {
                     var taskGroup = new List<RenderTask>();
-                    for (int i = 0; i < processorCount && batch.Tasks.Count > 0; i++)
+                    for (int i = 0; i < processorCount / 2 && batch.Tasks.Count > 0; i++)
                     {
                         taskGroup.Add(batch.Tasks.Dequeue());
                     }
                     Parallel.ForEach(taskGroup,
-                        new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount }, renderTask =>
+                        new ParallelOptions { MaxDegreeOfParallelism = processorCount / 2 }, renderTask =>
                         {
                             try
                             {

--- a/Thundagun.cs
+++ b/Thundagun.cs
@@ -514,7 +514,7 @@ public static class ThreadLogger
             while (true)
             {
                 Thundagun.Msg($"Unity: {SynchronizationManager.UnityEMA} Resonite: {SynchronizationManager.ResoniteEMA} Mode: {SynchronizationManager.CurrentSyncMode}");
-                Thread.Sleep((int)(1.0f / Thundagun.Config.GetValue(Thundagun.LoggingRate)));
+                Thread.Sleep((int)(1.0f / Thundagun.Config.GetValue(Thundagun.LoggingRate) * 1000.0f));
             }
         });
     }

--- a/Thundagun.cs
+++ b/Thundagun.cs
@@ -65,9 +65,11 @@ public class Thundagun : ResoniteMod
     [AutoRegisterConfigKey]
     internal readonly static ModConfigurationKey<double> TimeoutCooldown =
     new("TimeoutCooldown", "Timeout Cooldown: The time required after a panic to listen for thresholds again.", () => 1000.0);
-    [AutoRegisterConfigKey]
-    internal readonly static ModConfigurationKey<double> TimeoutWorkInterval =
-    new("TimeoutWorkInterval", "Timeout Work Interval: The max amount of time Unity will spend processing changes during a timeout.", () => 100.0);
+
+    [AutoRegisterConfigKey] internal readonly static ModConfigurationKey<double> TimeoutWorkInterval =
+        new("TimeoutWorkInterval",
+            "Timeout Work Interval: The max amount of time Unity will spend processing changes during a timeout.",
+            () => 16.67);
     [AutoRegisterConfigKey]
     internal readonly static ModConfigurationKey<float> EMAExponent =
         new("EMAExponent", "EMA Exponent: The exponent used for the exponential moving average for calculating framerate.", () => 0.1f);


### PR DESCRIPTION
Adds RenderTask parallelization by handling them over multiple logical processors. Setting the maxParallelization to processorCount caused Unity to crash, which is probably a result of not leaving any processors free for other tasks. Right now, I just set this to processorCount / 2, but if we want to expose this more directly we could.