### PR TITLE
Prerelease prep

### DIFF
--- a/NewConnectors/ComponentConnectors/CameraPortalConnector.cs
+++ b/NewConnectors/ComponentConnectors/CameraPortalConnector.cs
@@ -52,7 +52,7 @@ public class ApplyChangesCameraPortalConnector : UpdatePacket<CameraPortalConnec
         MeshRenderer = target?.Connector as MeshRendererConnector;
         Engine = owner.Owner.Engine;
 
-        if (target?.Mesh.Target != null && MeshRenderer == null && target.IsChangeDirty) owner.Owner.MarkChangeDirty();
+        if (target?.Mesh.Target != null && MeshRenderer.MeshRenderer.gameObject == null && target.IsChangeDirty) owner.Owner.MarkChangeDirty();
 
         var v = MathX.FilterInvalid(owner.Owner.PlaneNormal);
         if (v.SqrMagnitude < 1E-06f) v = float3.Forward;
@@ -63,8 +63,8 @@ public class ApplyChangesCameraPortalConnector : UpdatePacket<CameraPortalConnec
         OverrideClearFlag = owner.Owner.OverrideClear.Value?.ToUnity();
         OverrideFarClip = owner.Owner.OverrideFarClip.Value;
         OverrideNearClip = owner.Owner.OverrideNearClip.Value;
-        DisablePixelLights = owner.Owner.DisablePerPixelLights.Value;
-        DisableShadows = owner.Owner.DisableShadows.Value;
+        DisablePixelLights = owner.Owner.DisablePerPixelLights;
+        DisableShadows = owner.Owner.DisableShadows;
         var value = owner.Owner.RenderMode.Value;
         if (value != 0 && value == FrooxEngine.CameraPortal.Mode.Portal)
         {
@@ -85,6 +85,10 @@ public class ApplyChangesCameraPortalConnector : UpdatePacket<CameraPortalConnec
             Owner.Cleanup(destroyingWorld: false);
             if (gameObject != null)
             {
+                if (CameraPortalConnector.LayerMask == 0)
+                {
+                    CameraPortalConnector.LayerMask = ~LayerMask.GetMask("Private", "Overlay");
+                }
                 Owner.currentPortal = gameObject.AddComponent<CameraPortal>();
                 Owner.currentPortal.ReflectLayers = CameraPortalConnector.LayerMask;
                 Owner.currentPortal.Engine = Engine;

--- a/NewConnectors/RenderQueueProcessor.cs
+++ b/NewConnectors/RenderQueueProcessor.cs
@@ -57,7 +57,7 @@ public class RenderQueueProcessor : MonoBehaviour
             RenderHelper.BeginRenderContext(RenderingContext.RenderToAsset);
 
             DateTime startTime = DateTime.Now;
-            double timeElapsed;
+            TimeSpan timeElapsed;
 
             while (_batchQueue.Count > 0)
             {
@@ -79,15 +79,16 @@ public class RenderQueueProcessor : MonoBehaviour
                     {
                         renderTask.task.SetException(ex);
                     }
-                    timeElapsed = (DateTime.Now - startTime).TotalMilliseconds;
-                    if (timeElapsed > Thundagun.Config.GetValue(Thundagun.DesyncWorkInterval) && SynchronizationManager.CurrentSyncMode == SyncMode.Desync)
+                    timeElapsed = (DateTime.Now - startTime);
+                    if (timeElapsed.TotalMilliseconds > Thundagun.Config.GetValue(Thundagun.MaxWorkInterval))
                     {
                         break;
                     }
                 }
-                timeElapsed = (DateTime.Now - startTime).TotalMilliseconds;
-                if (timeElapsed > Thundagun.Config.GetValue(Thundagun.DesyncWorkInterval) && SynchronizationManager.CurrentSyncMode == SyncMode.Desync)
+                timeElapsed = (DateTime.Now - startTime);
+                if (timeElapsed.TotalMilliseconds > Thundagun.Config.GetValue(Thundagun.MaxWorkInterval))
                 {
+                    SynchronizationManager.AddUnityWorkTime(timeElapsed);
                     break;
                 }
                 if (batch.IsComplete && batch.Tasks.Count == 0)

--- a/NewConnectors/RenderQueueProcessor.cs
+++ b/NewConnectors/RenderQueueProcessor.cs
@@ -14,6 +14,17 @@ public class RenderQueueProcessor : MonoBehaviour
 
     private Queue<Batch> _batchQueue = new();
 
+    // Normally there isn't a constructor here
+    public RenderQueueProcessor()
+    {
+        Thundagun.MarkAsCompletedAction = MarkAsCompleted;
+    }
+
+    public void MarkAsCompleted()
+    {
+        _batchQueue.Last().IsComplete = true;
+    }
+
     public Task<byte[]> Enqueue(FrooxEngine.RenderSettings settings)
     {
         var task = new TaskCompletionSource<byte[]>();
@@ -103,5 +114,5 @@ public class RenderQueueProcessor : MonoBehaviour
 public class Batch
 {
     public Queue<RenderTask> Tasks { get; private set; } = new();
-    public bool IsComplete { get; private set; } = false;
+    public bool IsComplete { get; set; } = false;
 }

--- a/NewConnectors/RenderQueueProcessor.cs
+++ b/NewConnectors/RenderQueueProcessor.cs
@@ -59,7 +59,7 @@ public class RenderQueueProcessor : MonoBehaviour
             {
                 var batch = _batchQueue.Peek();
 
-                if (!batch.IsComplete && SynchronizationManager.CurrentSyncMode == SyncMode.Async && !SynchronizationManager.Timeout)
+                if (!batch.IsComplete && SynchronizationManager.CurrentSyncMode == SyncMode.Async)
                 {
                     return;
                 }
@@ -76,13 +76,13 @@ public class RenderQueueProcessor : MonoBehaviour
                         renderTask.task.SetException(ex);
                     }
                     timeElapsed = (DateTime.Now - startTime).TotalMilliseconds;
-                    if (timeElapsed > Thundagun.Config.GetValue(Thundagun.TimeoutWorkInterval) && SynchronizationManager.Timeout)
+                    if (timeElapsed > Thundagun.Config.GetValue(Thundagun.DesyncWorkInterval))
                     {
                         break;
                     }
                 }
                 timeElapsed = (DateTime.Now - startTime).TotalMilliseconds;
-                if (timeElapsed > Thundagun.Config.GetValue(Thundagun.TimeoutWorkInterval) && SynchronizationManager.Timeout)
+                if (timeElapsed > Thundagun.Config.GetValue(Thundagun.DesyncWorkInterval))
                 {
                     break;
                 }

--- a/NewConnectors/RenderQueueProcessor.cs
+++ b/NewConnectors/RenderQueueProcessor.cs
@@ -22,7 +22,8 @@ public class RenderQueueProcessor : MonoBehaviour
 
     public void MarkAsCompleted()
     {
-        _batchQueue.Last().IsComplete = true;
+        if (_batchQueue.Count != 0)
+            _batchQueue.Last().IsComplete = true;
     }
 
     public Task<byte[]> Enqueue(FrooxEngine.RenderSettings settings)
@@ -43,16 +44,8 @@ public class RenderQueueProcessor : MonoBehaviour
         return task.Task;
     }
 
-    private int GetLastBatchTaskCount()
-    {
-        if (_batchQueue.Count == 0)
-            return 0;
-        return _batchQueue.Last().Tasks.Count;
-    }
-
     private void LateUpdate()
     {
-        Thundagun.Msg($"Backmost batch task count: {GetLastBatchTaskCount()}");
         lock (_batchQueue)
         {
             if (_batchQueue.Count == 0)
@@ -87,13 +80,13 @@ public class RenderQueueProcessor : MonoBehaviour
                         renderTask.task.SetException(ex);
                     }
                     timeElapsed = (DateTime.Now - startTime).TotalMilliseconds;
-                    if (timeElapsed > Thundagun.Config.GetValue(Thundagun.DesyncWorkInterval))
+                    if (timeElapsed > Thundagun.Config.GetValue(Thundagun.DesyncWorkInterval) && SynchronizationManager.CurrentSyncMode == SyncMode.Desync)
                     {
                         break;
                     }
                 }
                 timeElapsed = (DateTime.Now - startTime).TotalMilliseconds;
-                if (timeElapsed > Thundagun.Config.GetValue(Thundagun.DesyncWorkInterval))
+                if (timeElapsed > Thundagun.Config.GetValue(Thundagun.DesyncWorkInterval) && SynchronizationManager.CurrentSyncMode == SyncMode.Desync)
                 {
                     break;
                 }

--- a/README.md
+++ b/README.md
@@ -9,10 +9,9 @@ Thundagun is a Resonite mod that decouples the FrooxEngine and Unity loops by ru
 - **Parallel Execution**: Maximizes CPU and GPU utilization by running Resonite and Unity on separate threads.
 - **Sync Mode**: Ensures a consistent 1:1 ratio between game updates and frames for stable visuals.
 - **Async Mode**: Allows Unity to render frames independently, improving responsiveness by potentially processing multiple finished states to use the latest or by rendering older finished states when new ones aren't available.
-- **Desync Mode**: Allows Resonite to send incremental changes to Unity during long engine stalls.
+- **Desync Mode**: Allows Unity process incremental changes from Resonite during long engine stalls.
 - **Stall Prevention**: Uses a configurable timeout to ensure frames continue to be rendered even during massive change queuing, like world loading.
 - **Auto Switching**: Enables thresholds to be defined for switching dynamically between sync, async, and desync modes based on game performance.
-- **Decoupled Input Handling**: Moves input, IK, and locomotion processing to Unity, enabling continuous player movement and camera control during stalls.
 
 ## Installation
 

--- a/Thundagun.cs
+++ b/Thundagun.cs
@@ -228,7 +228,7 @@ public static class FrooxEngineRunnerPatch
                             Task.Delay(ticktime - engineTime);
                         }
 
-
+                        // how to communicate completion status? Move to sync manager?
                         RenderConnector.renderQueue.MarkAsCompleted();
                         // I believe this is the last step in the main Resonite update loop
                         SynchronizationManager.OnResoniteUpdate();

--- a/Thundagun.cs
+++ b/Thundagun.cs
@@ -57,15 +57,15 @@ public class Thundagun : ResoniteMod
             false, value => value > 1);
     [AutoRegisterConfigKey]
     internal readonly static ModConfigurationKey<double> SyncToAsyncRatioThreshold =
-        new("SyncToAsyncRatioThreshold", "Sync To Async Ratio Threshold: The ratio threshold to switch from sync to async.", () => 4.0,
+        new("SyncToAsyncRatioThreshold", "Sync To Async Ratio Threshold: The frametime ratio threshold to switch from sync to async.", () => 4.0,
             false, value => value > 1);
     [AutoRegisterConfigKey]
     internal readonly static ModConfigurationKey<double> AsyncToDesyncRatioThreshold =
-    new("AsyncToDesyncRatioThreshold", "Async To Desync Ratio Threshold: The ratio threshold to switch from async to desync.", () => 16.0,
+    new("AsyncToDesyncRatioThreshold", "Async To Desync Ratio Threshold: The frametime ratio threshold to switch from async to desync.", () => 16.0,
         false, value => value > 2);
     [AutoRegisterConfigKey]
     internal readonly static ModConfigurationKey<double> MaxWorkInterval =
-        new("MaxWorkInterval", "Max Work Interval: The max amount of time in milliseconds Unity will spend processing changes.", () => 100.0,
+        new("MaxWorkInterval", "Max Work Interval: The max amount of time in milliseconds Unity will spend in total processing changes and waiting on a sync lock.", () => 100.0,
             false, value => value < 1000 || value > 1);
     [AutoRegisterConfigKey]
     internal readonly static ModConfigurationKey<float> EMAExponent =

--- a/Thundagun.cs
+++ b/Thundagun.cs
@@ -30,6 +30,8 @@ public class Thundagun : ResoniteMod
 
     public static Task FrooxEngineTask;
 
+    public static Action MarkAsCompletedAction;
+
     public static void QueuePacket(IUpdatePacket packet)
     {
         lock (CurrentPackets) CurrentPackets.Enqueue(packet);
@@ -538,6 +540,8 @@ public static class SynchronizationManager
     }
     public static void OnResoniteUpdate()
     {
+        Thundagun.MarkAsCompletedAction?.Invoke();
+
         var elapsed = (DateTime.Now - ResoniteStartTime).TotalMilliseconds;
         double alpha = Mathf.Clamp(Thundagun.Config.GetValue(Thundagun.EMAExponent), 0.001f, 0.999f);
         ResoniteEMA = alpha * elapsed + (1 - alpha) * ResoniteEMA;

--- a/Thundagun.cs
+++ b/Thundagun.cs
@@ -29,7 +29,7 @@ public class Thundagun : ResoniteMod
 
     public static double Performance;
     
-    public static readonly Queue<IUpdatePacket> CurrentPackets = new(); 
+    public static readonly Queue<IUpdatePacket> CurrentPackets = new();
 
     public static Task CurrentTask;
 
@@ -289,8 +289,9 @@ public static class FrooxEngineRunnerPatch
                 
                 if (Thundagun.Config.GetValue(Thundagun.DebugLogging))
                 {
-                    Thundagun.Msg($"LastRender vs now: {(lastrender - starttime).TotalSeconds}");
-                    Thundagun.Msg($"Boilerplate: {(boilerplateTime - starttime).TotalSeconds} Asset Integration time: {(assetTime - boilerplateTime).TotalSeconds} Loop time: {(loopTime - assetTime).TotalSeconds} Update time: {(updateTime - loopTime).TotalSeconds} Finished: {(finishTime - updateTime).TotalSeconds} total time: {(finishTime - starttime).TotalSeconds} Current mode: {SynchronizationManager.CurrentSyncMode} Unity update time: {SynchronizationManager.UnityEMA} FrooxEngine update time: {SynchronizationManager.ResoniteEMA}");
+                    Thundagun.Msg($"Unity: {SynchronizationManager.UnityEMA} Resonite: {SynchronizationManager.ResoniteEMA} Mode: {SynchronizationManager.CurrentSyncMode} Timeout: {SynchronizationManager.Timeout}");
+                    //Thundagun.Msg($"LastRender vs now: {(lastrender - starttime).TotalSeconds}");
+                    //Thundagun.Msg($"Boilerplate: {(boilerplateTime - starttime).TotalSeconds} Asset Integration time: {(assetTime - boilerplateTime).TotalSeconds} Loop time: {(loopTime - assetTime).TotalSeconds} Update time: {(updateTime - loopTime).TotalSeconds} Finished: {(finishTime - updateTime).TotalSeconds} total time: {(finishTime - starttime).TotalSeconds}");
                 }
                 lastrender = DateTime.Now;
             }
@@ -481,41 +482,6 @@ public abstract class UpdatePacket<T> : IUpdatePacket
 public interface IUpdatePacket
 {
     public void Update();
-}
-public class PerformanceTimer
-{
-    private string Name;
-    private Stopwatch timer;
-
-    public PerformanceTimer(string name)
-    {
-        Name = name;
-        timer = new Stopwatch();
-        timer.Start();
-    }
-
-    public void End()
-    {
-        timer.Stop();
-        Thundagun.Msg($"{Name}: {timer.Elapsed.TotalSeconds}");
-    }
-}
-
-public static class ThreadLogger
-{
-    public static Task Task;
-
-    static ThreadLogger()
-    {
-        Task = Task.Run(() =>
-        {
-            while (true)
-            {
-                Thundagun.Msg($"Unity: {SynchronizationManager.UnityEMA} Resonite: {SynchronizationManager.ResoniteEMA} Mode: {SynchronizationManager.CurrentSyncMode}");
-                Thread.Sleep((int)(1.0f / Thundagun.Config.GetValue(Thundagun.LoggingRate)));
-            }
-        });
-    }
 }
 
 

--- a/Thundagun.cs
+++ b/Thundagun.cs
@@ -65,7 +65,7 @@ public class Thundagun : ResoniteMod
         false, value => value > 2);
     [AutoRegisterConfigKey]
     internal readonly static ModConfigurationKey<double> DesyncWorkInterval =
-        new("TimeoutWorkInterval", "Timeout Work Interval: The max amount of time in milliseconds Unity will spend processing changes in desync mode.", () => 100.0,
+        new("TimeoutWorkInterval", "Timeout Work Interval: The max amount of time in milliseconds Unity will spend processing changes in desync mode.", () => 16.67,
             false, value => value < 1000 || value > 1);
     [AutoRegisterConfigKey]
     internal readonly static ModConfigurationKey<double> TimeoutThreshold =

--- a/Thundagun.cs
+++ b/Thundagun.cs
@@ -65,7 +65,7 @@ public class Thundagun : ResoniteMod
         false, value => value > 2);
     [AutoRegisterConfigKey]
     internal readonly static ModConfigurationKey<double> DesyncWorkInterval =
-        new("TimeoutWorkInterval", "Timeout Work Interval: The max amount of time in milliseconds Unity will spend processing changes in desync mode.", () => 16.67,
+        new("DesyncWorkInterval", "Desync Work Interval: The max amount of time in milliseconds Unity will spend processing changes in desync mode.", () => 16.67,
             false, value => value < 1000 || value > 1);
     [AutoRegisterConfigKey]
     internal readonly static ModConfigurationKey<double> TimeoutThreshold =

--- a/Thundagun.cs
+++ b/Thundagun.cs
@@ -549,14 +549,23 @@ public static class SynchronizationManager
 
         lock (SyncLock)
         {
-            while (_lockResoniteUnlockUnity) Monitor.Wait(SyncLock);
+            while (_lockResoniteUnlockUnity)
+            {
+                if (CurrentSyncMode != SyncMode.Sync) break;
+                // we need some form of polling to see if the timeout has been triggered
+                // or do we?
+                // try removing the wait?
+                Monitor.Wait(SyncLock, TimeSpan.FromMilliseconds(0.1));
+            }
             Monitor.Pulse(SyncLock);
+
             _lockResoniteUnlockUnity = true;
         }
 
         
         ResoniteStartTime = DateTime.Now;
     }
+    // might be a little heavy, but most of these operations are fairly light anyway
     public static SyncMode CurrentSyncMode
     {
         get

--- a/Thundagun.csproj
+++ b/Thundagun.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net4.7.2</TargetFramework>
     <ResonitePath>$(MSBuildThisFileDirectory)Resonite</ResonitePath>
     <ResonitePath Condition="Exists('C:\Program Files (x86)\Steam\steamapps\common\Resonite\')">C:\Program Files (x86)\Steam\steamapps\common\Resonite\</ResonitePath>
+	<ResonitePath Condition="Exists('G:\SteamLibrary\steamapps\common\Resonite\')">G:\SteamLibrary\steamapps\common\Resonite\</ResonitePath>
 	  <ResonitePath Condition="Exists('D:\SteamLibrary\steamapps\common\Resonite\')">D:\SteamLibrary\steamapps\common\Resonite\</ResonitePath>
 	  <ResonitePath Condition="Exists('$(HOME)/.steam/steam/steamapps/common/Resonite/')">$(HOME)/.steam/steam/steamapps/common/Resonite/</ResonitePath>
     <ResonitePath Condition="Exists('/mnt/LocalDisk2/SteamLibrary/steamapps/common/Resonite/')">/mnt/LocalDisk2/SteamLibrary/steamapps/common/Resonite/</ResonitePath>


### PR DESCRIPTION
Working on cleaning things up and ensuring all connector functionality is up to date in preparation for a prerelease. Will generally avoid running formatters on existing code to reduce the number of merge conflicts possible.

Mostly just collapses the timeout logic to use the exponential-moving-average frame time directly, with the timeouts used to force-update the EMA for sudden stalls.