### PR TITLE
Unify existing systems

### DIFF
--- a/NewConnectors/RenderQueueProcessor.cs
+++ b/NewConnectors/RenderQueueProcessor.cs
@@ -61,7 +61,7 @@ public class RenderQueueProcessor : MonoBehaviour
             TimeSpan timeElapsed;
 
             TimeSpan unityLastNonWorkInterval = SynchronizationManager.UnityLastUpdateInterval - LastWorkInterval;
-            TimeSpan unityAllowedWorkInterval = TimeSpan.FromMilliseconds(Thundagun.Config.GetValue(Thundagun.MaxUpdateInterval)) - unityLastNonWorkInterval;
+            TimeSpan unityAllowedWorkInterval = TimeSpan.FromMilliseconds(1000.0 / Thundagun.Config.GetValue(Thundagun.MinUnityTickRate)) - unityLastNonWorkInterval;
 
             while (_batchQueue.Count > 0)
             {

--- a/NewConnectors/RenderQueueProcessor.cs
+++ b/NewConnectors/RenderQueueProcessor.cs
@@ -68,7 +68,7 @@ public class RenderQueueProcessor : MonoBehaviour
                 var batch = _batchQueue.Peek();
 
                 // We might not actually need batching anymore, but I'll leave it in for frame consistency?
-                if (!batch.IsComplete)
+                if (!batch.IsComplete && !SynchronizationManager.IsUnityStalling && !SynchronizationManager.IsResoniteStalling)
                 {
                     return;
                 }

--- a/NewConnectors/RenderQueueProcessor.cs
+++ b/NewConnectors/RenderQueueProcessor.cs
@@ -13,7 +13,7 @@ public class RenderQueueProcessor : MonoBehaviour
     public RenderConnector Connector;
 
     private Queue<Batch> _batchQueue = new();
-    private TimeSpan LastWorkInterval = TimeSpan.FromMilliseconds(1);
+    private TimeSpan LastWorkInterval = TimeSpan.Zero;
 
     // Normally there isn't a constructor here
     public RenderQueueProcessor()

--- a/NewConnectors/RenderQueueProcessor.cs
+++ b/NewConnectors/RenderQueueProcessor.cs
@@ -13,7 +13,7 @@ public class RenderQueueProcessor : MonoBehaviour
     public RenderConnector Connector;
 
     private Queue<Batch> _batchQueue = new();
-    private TimeSpan LastWorkInterval = TimeSpan.FromMilliseconds(10);
+    private TimeSpan LastWorkInterval = TimeSpan.Zero;
 
     // Normally there isn't a constructor here
     public RenderQueueProcessor()

--- a/NewConnectors/RenderQueueProcessor.cs
+++ b/NewConnectors/RenderQueueProcessor.cs
@@ -13,7 +13,7 @@ public class RenderQueueProcessor : MonoBehaviour
     public RenderConnector Connector;
 
     private Queue<Batch> _batchQueue = new();
-    private TimeSpan LastWorkInterval = TimeSpan.Zero;
+    private TimeSpan LastWorkInterval = TimeSpan.FromMilliseconds(1);
 
     // Normally there isn't a constructor here
     public RenderQueueProcessor()

--- a/README.md
+++ b/README.md
@@ -8,10 +8,8 @@ Thundagun is a lightning fast performance mod for Resonite. It improves performa
 
 - **Parallel Execution**: Maximizes CPU and GPU utilization by running Resonite and Unity on separate threads.
 - **Sync Mode**: Ensures a consistent 1:1 ratio between game updates and frames for stable visuals.
-- **Async Mode**: Allows Unity to render frames independently, improving responsiveness by potentially processing multiple finished states to use the latest or by rendering older finished states when new ones aren't available.
-- **Desync Mode**: Allows Unity process incremental changes from Resonite during long engine stalls.
-- **Stall Prevention**: Uses a configurable timeout to ensure frames continue to be rendered even during massive change queuing, like world loading.
-- **Auto Switching**: Enables thresholds to be defined for switching dynamically between sync, async, and desync modes based on game performance.
+- **Async Mode**: Allows Unity and Resonite to update independently, protecting against stalls and letting through incremental changes from the engine.
+- **Auto Switching**: Enables thresholds to be defined for switching dynamically between sync and async modes based on game performance.
 
 ## Installation
 

--- a/Thundagun.cs
+++ b/Thundagun.cs
@@ -47,25 +47,25 @@ public class Thundagun : ResoniteMod
         new("DebugLogging", "Debug Logging: Whether to enable debug logging.", () => true, 
             false, value => true);
     [AutoRegisterConfigKey]
-    internal readonly static ModConfigurationKey<float> LoggingRate =
-      new("LoggingRate", "Logging Rate: The rate of log updates per second.", () => 10.0f, 
-          false, value => value > 0.001f || value < 1000.0f);
+    internal readonly static ModConfigurationKey<double> LoggingRate =
+      new("LoggingRate", "Logging Rate: The rate of log updates per second.", () => 10.0, 
+          false, value => value >= 0.001 || value <= 1000.0);
     [AutoRegisterConfigKey]
     internal readonly static ModConfigurationKey<double> MaxEngineTickRate =
         new("MaxEngineTickRate", "Max Engine Tick Rate: The max rate per second at which FrooxEngine can update.", () => 1000.0,
-            false, value => value > 10.0);
+            false, value => value >= 10.0);
     [AutoRegisterConfigKey]
     internal readonly static ModConfigurationKey<double> MaxUnityTickRate =
         new("MaxUnityTickRate", "Max Unity Tick Rate: The max rate per second at which Unity can update.", () => 1000.0,
-            false, value => value > 10.0);
+            false, value => value >= 10.0);
     [AutoRegisterConfigKey]
     internal readonly static ModConfigurationKey<double> MinEngineTickRate =
         new("MinEngineTickRate", "Min Engine Tick Rate: The min acceptable rate per second at which FrooxEngine should update.", () => 10.0,
-            false, value => value > 5.0);
+            false, value => value >= 10.0);
     [AutoRegisterConfigKey]
     internal readonly static ModConfigurationKey<double> MinUnityTickRate =
     new("MinUnityTickRate", "Min Unity Tick Rate: The min acceptable rate per second at which Unity should update..", () => 10.0,
-        false, value => value > 5.0);
+        false, value => value >= 10.0);
 
     public override void OnEngineInit()
     {
@@ -595,10 +595,10 @@ public static class SynchronizationManager
 
         UnityLastUpdateInterval = interval;
 
-        var ticktime = TimeSpan.FromMilliseconds((1000 / Thundagun.Config.GetValue(Thundagun.MaxUnityTickRate)));
+        var ticktime = TimeSpan.FromMilliseconds((1000.0 / Thundagun.Config.GetValue(Thundagun.MaxUnityTickRate)));
         if (UnityLastUpdateInterval < ticktime)
         {
-            Task.Delay(ticktime - UnityLastUpdateInterval);
+            Thread.Sleep(ticktime - UnityLastUpdateInterval);
         }
 
         UnityStartTime = DateTime.Now;
@@ -627,10 +627,10 @@ public static class SynchronizationManager
 
         ResoniteLastUpdateInterval = DateTime.Now - ResoniteStartTime;
 
-        var ticktime = TimeSpan.FromMilliseconds(1000 / Thundagun.Config.GetValue(Thundagun.MaxEngineTickRate));
+        var ticktime = TimeSpan.FromMilliseconds(1000.0 / Thundagun.Config.GetValue(Thundagun.MaxEngineTickRate));
         if (ResoniteLastUpdateInterval < ticktime)
         {
-            Task.Delay(ticktime - ResoniteLastUpdateInterval);
+            Thread.Sleep(ticktime - ResoniteLastUpdateInterval);
         }
 
         ResoniteStartTime = DateTime.Now;

--- a/Thundagun.cs
+++ b/Thundagun.cs
@@ -218,23 +218,12 @@ public static class FrooxEngineRunnerPatch
                         var beforeEngine = DateTime.Now;
                         engine.AssetsUpdated(total);
                         engine.RunUpdateLoop();
-                        var resoniteInterval = (DateTime.Now - SynchronizationManager.ResoniteStartTime);
-                        var ticktime = TimeSpan.FromSeconds((1 / Math.Abs(Thundagun.Config.GetValue(Thundagun.MaxEngineTickRate)) + 1));
-                        if (resoniteInterval < ticktime)
-                        {
-                            Task.Delay(ticktime - resoniteInterval);
-                        }
 
                         // I believe this is the last step in the main Resonite update loop
                         SynchronizationManager.OnResoniteUpdate();
                     }
                 });
-                var unityInterval = (DateTime.Now - SynchronizationManager.UnityStartTime);
-                var ticktime = TimeSpan.FromSeconds((1 / Math.Abs(Thundagun.Config.GetValue(Thundagun.MaxUnityTickRate)) + 1));
-                if (unityInterval < ticktime)
-                {
-                    Task.Delay(ticktime - unityInterval);
-                }
+
                 // technically not the last or first thing called, but it does happen only once per cycle
                 // less important than on Resonite, where you want all changes to be finished
                 SynchronizationManager.OnUnityUpdate();
@@ -606,6 +595,12 @@ public static class SynchronizationManager
 
         UnityLastUpdateInterval = interval;
 
+        var ticktime = TimeSpan.FromMilliseconds((1000 / Thundagun.Config.GetValue(Thundagun.MaxUnityTickRate)));
+        if (UnityLastUpdateInterval < ticktime)
+        {
+            Task.Delay(ticktime - UnityLastUpdateInterval);
+        }
+
         UnityStartTime = DateTime.Now;
     }
     public static void OnResoniteUpdate()
@@ -631,6 +626,12 @@ public static class SynchronizationManager
         IsResoniteStalling = false;
 
         ResoniteLastUpdateInterval = DateTime.Now - ResoniteStartTime;
+
+        var ticktime = TimeSpan.FromMilliseconds(1000 / Thundagun.Config.GetValue(Thundagun.MaxEngineTickRate));
+        if (ResoniteLastUpdateInterval < ticktime)
+        {
+            Task.Delay(ticktime - ResoniteLastUpdateInterval);
+        }
 
         ResoniteStartTime = DateTime.Now;
     }

--- a/Thundagun.cs
+++ b/Thundagun.cs
@@ -51,21 +51,21 @@ public class Thundagun : ResoniteMod
       new("LoggingRate", "Logging Rate: The rate of log updates per second.", () => 10.0f, 
           false, value => value > 0.001f || value < 1000.0f);
     [AutoRegisterConfigKey]
-    internal readonly static ModConfigurationKey<float> MaxEngineTickRate =
-        new("MaxEngineTickRate", "Max Engine Tick Rate: The max rate per second at which FrooxEngine can update.", () => 1000,
-            false, value => value > 1);
+    internal readonly static ModConfigurationKey<double> MaxEngineTickRate =
+        new("MaxEngineTickRate", "Max Engine Tick Rate: The max rate per second at which FrooxEngine can update.", () => 1000.0,
+            false, value => value > 10.0);
     [AutoRegisterConfigKey]
-    internal readonly static ModConfigurationKey<float> MaxUnityTickRate =
-        new("MaxUnityTickRate", "Max Unity Tick Rate: The max rate per second at which Unity can update.", () => 1000,
-            false, value => value > 1);
+    internal readonly static ModConfigurationKey<double> MaxUnityTickRate =
+        new("MaxUnityTickRate", "Max Unity Tick Rate: The max rate per second at which Unity can update.", () => 1000.0,
+            false, value => value > 10.0);
     [AutoRegisterConfigKey]
     internal readonly static ModConfigurationKey<double> MinEngineTickRate =
         new("MinEngineTickRate", "Min Engine Tick Rate: The min acceptable rate per second at which FrooxEngine should update.", () => 10.0,
-            false, value => value > 1);
+            false, value => value > 5.0);
     [AutoRegisterConfigKey]
     internal readonly static ModConfigurationKey<double> MinUnityTickRate =
     new("MinUnityTickRate", "Min Unity Tick Rate: The min acceptable rate per second at which Unity should update..", () => 10.0,
-        false, value => value > 2);
+        false, value => value > 5.0);
 
     public override void OnEngineInit()
     {

--- a/Thundagun.cs
+++ b/Thundagun.cs
@@ -514,8 +514,8 @@ public static class SynchronizationManager
     internal static readonly object SyncLock = new();
     public static DateTime UnityStartTime { get; internal set; } = DateTime.Now;
     public static DateTime ResoniteStartTime { get; internal set; } = DateTime.Now;
-    public static TimeSpan UnityLastUpdateInterval { get; internal set; } = TimeSpan.FromMilliseconds(100);
-    public static TimeSpan ResoniteLastUpdateInterval { get; internal set; } = TimeSpan.FromMilliseconds(100);
+    public static TimeSpan UnityLastUpdateInterval { get; internal set; } = TimeSpan.Zero;
+    public static TimeSpan ResoniteLastUpdateInterval { get; internal set; } = TimeSpan.Zero;
     internal static bool _lockResoniteUnlockUnity;
 
     public static bool IsResoniteStalling

--- a/Thundagun.cs
+++ b/Thundagun.cs
@@ -72,8 +72,6 @@ public class Thundagun : ResoniteMod
 
     public override void OnEngineInit()
     {
-        AsyncLogger.StartLogger();
-
         var harmony = new Harmony("Thundagun");
         Config = GetConfiguration();
 
@@ -589,6 +587,8 @@ public static class SynchronizationManager
     }
     public static void OnResoniteUpdate()
     {
+        AsyncLogger.StartLogger();
+
         Thundagun.MarkAsCompletedAction?.Invoke();
 
         IsResoniteStalling = false;

--- a/Thundagun.cs
+++ b/Thundagun.cs
@@ -537,10 +537,10 @@ public static class AsyncLogger
 public static class SynchronizationManager
 {
     internal static readonly object SyncLock = new();
-    public static DateTime UnityStartTime { get; internal set; } = DateTime.Now - TimeSpan.FromMilliseconds(10);
-    public static DateTime ResoniteStartTime { get; internal set; } = DateTime.Now - TimeSpan.FromMilliseconds(10);
-    public static TimeSpan UnityLastUpdateInterval { get; internal set; } = TimeSpan.FromMilliseconds(10);
-    public static TimeSpan ResoniteLastUpdateInterval { get; internal set; } = TimeSpan.FromMilliseconds(10);
+    public static DateTime UnityStartTime { get; internal set; } = DateTime.Now;
+    public static DateTime ResoniteStartTime { get; internal set; } = DateTime.Now;
+    public static TimeSpan UnityLastUpdateInterval { get; internal set; } = TimeSpan.Zero;
+    public static TimeSpan ResoniteLastUpdateInterval { get; internal set; } = TimeSpan.Zero;
     internal static bool _lockResoniteUnlockUnity;
     private static bool _isResoniteStalling = false;
     private static bool _isUnityStalling = false;

--- a/Thundagun.cs
+++ b/Thundagun.cs
@@ -26,8 +26,8 @@ namespace Thundagun;
 public class Thundagun : ResoniteMod
 {
     public override string Name => "Thundagun";
-    public override string Author => "Fro Zen, 989onan, DoubleStyx, Nytra";
-    public override string Version => "1.0.0-alpha";
+    public override string Author => "Fro Zen, 989onan, DoubleStyx, Nytra"; // in order of first commit
+    public override string Version => "1.1.0-alpha"; // change minor version for config "API" changes
     
     public static readonly Queue<IUpdatePacket> CurrentPackets = new();
 

--- a/Thundagun.csproj
+++ b/Thundagun.csproj
@@ -17,7 +17,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="5.3.4" />
+    <PackageReference Include="Serilog" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Thundagun.csproj
+++ b/Thundagun.csproj
@@ -17,6 +17,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="NLog" Version="5.3.4" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Reference Include="ResoniteModLoader">
       <HintPath Condition="Exists('$(ResonitePath)ResoniteModLoader.dll')">$(ResonitePath)ResoniteModLoader.dll</HintPath>
       <HintPath Condition="Exists('$(ResonitePath)Libraries/ResoniteModLoader.dll')">$(ResonitePath)Libraries/ResoniteModLoader.dll</HintPath>
@@ -94,8 +98,8 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="copy &quot;$(TargetDir)\$(TargetFileName)&quot; &quot;$(ResonitePath)\rml_mods\&quot;" Condition="$([MSBuild]::IsOSPlatform('Windows'))"/>
-    <Exec Command="cp -u &quot;$(TargetDir)/$(TargetFileName)&quot; &quot;$(ResonitePath)/rml_mods/&quot;" Condition="$([MSBuild]::IsOSPlatform('Linux'))"/>
+    <Exec Command="copy &quot;$(TargetDir)\$(TargetFileName)&quot; &quot;$(ResonitePath)\rml_mods\&quot;" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
+    <Exec Command="cp -u &quot;$(TargetDir)/$(TargetFileName)&quot; &quot;$(ResonitePath)/rml_mods/&quot;" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
   </Target>
 
 </Project>


### PR DESCRIPTION
I came up with a simple solution to all of the different modes, frametime estimation, and timeout behavior. It just exposes two config options:

MinEngineTickRate
MinUnityTickRate

Through this, it automatically determines whether to use sync, how long to spend processing changes, etc.