### PR TITLE
State guard

### DIFF
--- a/NewConnectors/RenderQueueProcessor.cs
+++ b/NewConnectors/RenderQueueProcessor.cs
@@ -11,8 +11,7 @@ namespace Thundagun.NewConnectors;
 public class RenderQueueProcessor : MonoBehaviour
 {
     public Queue<RenderTask> Tasks { get; private set; } = new();
-    public bool IsCompleteEngine { get; set; } = false;
-    public bool IsCompleteUnity { get; set; } = false;
+    public static bool IsCompleteEngine { get; set; } = false;
 
     public RenderConnector Connector;
     private TimeSpan LastWorkInterval = TimeSpan.Zero;
@@ -33,28 +32,6 @@ public class RenderQueueProcessor : MonoBehaviour
     public RenderQueueProcessor()
     {
         Instance = this;
-    }
-
-    // convenience method
-    public static void MarkIsCompleteEngine()
-    {
-        RenderQueueProcessor instance = Instance;
-        Instance.IsCompleteEngine = true;
-    }
-
-    // convenience method
-    public static bool GetIsCompleteUnity()
-    {
-        RenderQueueProcessor instance = Instance;
-        if (instance != null)
-        {
-            if (instance.Tasks.Count != 0)
-            {
-                return instance.IsCompleteUnity;
-            }
-            return false;
-        }
-        return false;
     }
 
     public Task<byte[]> Enqueue(FrooxEngine.RenderSettings settings)
@@ -106,17 +83,15 @@ public class RenderQueueProcessor : MonoBehaviour
                     break;
                 }
             }
-            timeElapsed = (DateTime.Now - startTime);
-            if (IsCompleteEngine && Tasks.Count == 0)
-            {
-                IsCompleteUnity = true;
-            }
 
             timeElapsed = (DateTime.Now - startTime);
             LastWorkInterval = timeElapsed;
 
-            // end critical region
-            SynchronizationManager.UnlockResonite();
+            timeElapsed = (DateTime.Now - startTime);
+            if (IsCompleteEngine && Tasks.Count == 0)
+            {
+                SynchronizationManager.UnlockResonite();
+            }
 
             if (renderingContext.HasValue)
             {

--- a/NewConnectors/UnityAssetIntegrator.cs
+++ b/NewConnectors/UnityAssetIntegrator.cs
@@ -26,7 +26,6 @@ public class UnityAssetIntegrator : IAssetManagerConnector
     private ConcurrentQueue<Action> _taskQueue = new();
     private Stopwatch _stopwatch = new();
     private double _maxMilliseconds;
-    private Action<int> renderThreadCallback;
     private IntPtr renderThreadPointer;
     public Engine Engine => AssetManager.Engine;
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Thundagun is a lightning fast performance mod for Resonite. It improves performa
 
 - **Parallel Execution**: Maximizes CPU and GPU utilization by running Resonite and Unity on separate threads.
 - **Sync Mode**: Ensures a consistent 1:1 ratio between game updates and frames for stable visuals.
-- **Async Mode**: Allows Unity and Resonite to update independently, protecting against stalls and letting through incremental changes from the engine.
+- **Async Mode**: Allows Unity to update independently of Resonite, protecting against stalls.
 - **Auto Switching**: Enables thresholds to be defined for switching dynamically between sync and async modes based on game performance.
 
 ## Installation


### PR DESCRIPTION
I should've realized this earlier. Oh well. Basically just removes all of the logic relating to allowing FrooxEngine to run faster than Unity. Since there is no state buffer, allowing FrooxEngine to update will almost always break a few references in various RenderTasks. Disallowing this behavior entirely essentially solves any issue relating to this kind of determinism.