### PR TITLE
Patch DuplicableDisplay.Update to run on the Unity thread, fixes desktop viewer crash. Add publicizer package to make accessing private fields easy

### DIFF
--- a/NewConnectors/AssetConnectors/DesktopTextureConnector.cs
+++ b/NewConnectors/AssetConnectors/DesktopTextureConnector.cs
@@ -3,8 +3,124 @@ using Elements.Core;
 using FrooxEngine;
 using UnityEngine;
 using UnityFrooxEngineRunner;
+using HarmonyLib;
+using uDesktopDuplication;
+using uWindowCapture;
+using Texture = UnityEngine.Texture;
+using System.Reflection;
+using System.Collections.Generic;
 
 namespace Thundagun.NewConnectors.AssetConnectors;
+
+public class DesktopUpdatePacket : UpdatePacket<DuplicableDisplay>
+{
+    DuplicableDisplay Display;
+    uDesktopDuplication.Monitor Monitor;
+	static Type stateType;
+	static FieldInfo currentStateField;
+	List<Action> _requests;
+	uDesktopDuplication.Monitor _monitor;
+	object currentState;
+	UwcWindow _window;
+	enum State2
+	{
+		DirectCapture,
+		WaitingOnWindow,
+		WaitingOnTexture,
+		UsingWindowCapture
+	}
+    public DesktopUpdatePacket(DuplicableDisplay owner, uDesktopDuplication.Monitor monitor) : base(owner)
+    {
+        Display = owner;
+        Monitor = monitor;
+		stateType ??= Display.currentState.GetType();
+		currentStateField ??= AccessTools.Field(Display.GetType(), "currentState");
+		_requests = Display._requests;
+		_monitor = Display._monitor;
+		_window = Display._window;
+		currentState = Display.currentState;
+    }
+
+    public override void Update()
+	{
+		//Thundagun.Msg("DesktopUpdatePacket Update start");
+        if (_requests.Count == 0)
+		{
+			//Thundagun.Msg("Requests count 0");
+			Display._monitor = null;
+			Display._window = null;
+			Display.UpdateProperties(Monitor);
+			return;
+		}
+		bool flag = false;
+		if (Monitor != _monitor || ((int)currentState != 0 && (int)currentState != (int)State2.UsingWindowCapture))
+		{
+			if ((int)currentState != 0)
+			{
+				UniLog.Log($"Monitor {Monitor.id}, name: {Monitor.name}, state: {Monitor.state}");
+			}
+			if (Monitor.state == DuplicatorState.Unsupported)
+			{
+				//Thundagun.Msg("unsupported");
+				_ = UwcManager.instance;
+				Display._window = UwcManager.Find(Monitor.name, isAltTabWindow: false);
+				if (Display._window != null)
+				{
+					currentStateField.SetValue(Display, Enum.ToObject(stateType, (int)State2.WaitingOnTexture));
+					Display._window.captureMode = CaptureMode.BitBlt;
+					Display._window.cursorDraw = true;
+					UniLog.Log("Using fallback window capture: " + Display._window?.id);
+				}
+				else
+				{
+					currentStateField.SetValue(Display, Enum.ToObject(stateType, (int)State2.WaitingOnWindow));
+				}
+			}
+			else
+			{
+				currentStateField.SetValue(Display, Enum.ToObject(stateType, (int)State2.DirectCapture));
+				Display._window = null;
+			}
+			Display._monitor = Monitor;
+			flag = true;
+			if (_requests.Count > 0 && _window == null && (int)currentState == (int)State2.DirectCapture)
+			{
+				//Thundagun.Msg("creating texture if needed");
+				Display._monitor.CreateTextureIfNeeded();
+			}
+		}
+		if ((int)currentState != (int)State2.WaitingOnWindow)
+		{
+			if (_window != null)
+			{
+				//Thundagun.Msg("requesting capture");
+				Display._window.RequestCapture();
+			}
+			else
+			{
+				//Thundagun.Msg("rendering");
+				Display._monitor.Render();
+			}
+			//Thundagun.Msg("calling desktop rendered");
+			Engine.Current.DesktopRendered();
+		}
+		if ((int)currentState == (int)State2.WaitingOnTexture && _window?.texture != null)
+		{
+			flag = true;
+			currentStateField.SetValue(Display, Enum.ToObject(stateType, (int)State2.UsingWindowCapture));
+		}
+		Display.UpdateProperties(Monitor);
+		if (!flag || ((int)currentState != 0 && (int)currentState != (int)State2.UsingWindowCapture))
+		{
+			return;
+		}
+		foreach (Action request in _requests)
+		{
+			//Thundagun.Msg("request invoke");
+			request();
+		}
+    }
+}
 
 public class DesktopTextureConnector :
     AssetConnector,

--- a/Thundagun.csproj
+++ b/Thundagun.csproj
@@ -17,11 +17,15 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Krafs.Publicizer" Version="2.2.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Serilog" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
   </ItemGroup>
-
+  
   <ItemGroup>
     <Reference Include="ResoniteModLoader">
       <HintPath Condition="Exists('$(ResonitePath)ResoniteModLoader.dll')">$(ResonitePath)ResoniteModLoader.dll</HintPath>
@@ -100,6 +104,14 @@
       <HintPath Condition="Exists('$(ResonitePath)0Harmony.dll')">$(ResonitePath)0Harmony.dll</HintPath>
       <HintPath Condition="Exists('$(ResonitePath)rml_libs/0Harmony.dll')">$(ResonitePath)rml_libs/0Harmony.dll</HintPath>
     </Reference>
+  </ItemGroup>
+  
+  <ItemGroup>
+	<Publicize Include="Assembly-CSharp:DuplicableDisplay._monitor" />
+	<Publicize Include="Assembly-CSharp:DuplicableDisplay._window" />
+	<Publicize Include="Assembly-CSharp:DuplicableDisplay.currentState" />
+	<Publicize Include="Assembly-CSharp:DuplicableDisplay._requests" />
+	<Publicize Include="Assembly-CSharp:DuplicableDisplay.UpdateProperties" />
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">


### PR DESCRIPTION
This makes the desktop viewer work *sometimes*, other times it just shows a white image, but it doesn't crash anymore

Fixes https://github.com/Frozenreflex/Thundagun/issues/3