### PR TITLE
Fixed Startup Crash due to Resonite's ParticleSystem refactor. Hotfixed by …

### DIFF
--- a/NewConnectors/ComponentConnectors/ParticleSystemBehavior.cs
+++ b/NewConnectors/ComponentConnectors/ParticleSystemBehavior.cs
@@ -10,7 +10,7 @@ using ParticleSystem = UnityEngine.ParticleSystem;
 #endregion
 
 namespace Thundagun.NewConnectors.ComponentConnectors;
-
+using ParticleEmission = FrooxEngine.LegacyParticleEmission;
 public class ParticleSystemBehavior : ConnectorBehaviour<ParticleSystemConnector>
 {
     private const int GRANULARITY = 100;
@@ -38,9 +38,9 @@ public class ParticleSystemBehavior : ConnectorBehaviour<ParticleSystemConnector
 
     internal ParticleSystem.TrailModule pTrail;
 
-    internal FrooxEngine.ParticleSystem FrooxEngineParticleSystem => Connector.Owner;
+    internal FrooxEngine.LegacyParticleSystem FrooxEngineParticleSystem => Connector.Owner;
 
-    internal ParticleStyle ParticleStyle => FrooxEngineParticleSystem.Style.Target;
+    internal LegacyParticleStyle ParticleStyle => FrooxEngineParticleSystem.Style.Target;
 
     internal PhysicsManager Physics => Connector?.World?.Physics;
 

--- a/NewConnectors/ComponentConnectors/ParticleSystemConnector.cs
+++ b/NewConnectors/ComponentConnectors/ParticleSystemConnector.cs
@@ -8,7 +8,10 @@ using UnityEngine.Rendering;
 using UnityFrooxEngineRunner;
 using MaterialConnector = Thundagun.NewConnectors.AssetConnectors.MaterialConnector;
 using MeshConnector = Thundagun.NewConnectors.AssetConnectors.MeshConnector;
-using ParticleSystem = FrooxEngine.ParticleSystem;
+using ParticleSystem = FrooxEngine.LegacyParticleSystem;
+using ParticleStyle = FrooxEngine.LegacyParticleStyle;
+using ParticleAlignment = FrooxEngine.PhotonDust.LegacyParticleAlignment;
+using ParticleTrailMode = FrooxEngine.PhotonDust.LegacyParticleTrailMode;
 
 #endregion
 


### PR DESCRIPTION
…using the legacy ParticleSystem instead